### PR TITLE
Add hightlight for shifted character 

### DIFF
--- a/src/js/test/keymap.js
+++ b/src/js/test/keymap.js
@@ -11,6 +11,7 @@ export function highlightKey(currentKey) {
       $(".active-key").removeClass("active-key");
     }
 
+    let targetKey;
     let highlightKey;
     switch (currentKey) {
       case "\\":
@@ -49,12 +50,19 @@ export function highlightKey(currentKey) {
         highlightKey = "#KeySpace";
         break;
       default:
-        highlightKey = `#Key${currentKey}`;
+        targetKey =
+          layouts?.[window?.config?.layout].keys.find(
+            (ks) => ks[1] === currentKey
+          )?.[0] ?? currentKey;
+        highlightKey = `#Key${targetKey}`;
     }
 
     $(highlightKey).addClass("active-key");
     if (highlightKey === "#KeySpace") {
       $("#KeySpace2").addClass("active-key");
+    }
+    if (targetKey !== currentKey) {
+      $("#KeySpace").addClass("active-key");
     }
   } catch (e) {
     console.log("could not update highlighted keymap key: " + e.message);


### PR DESCRIPTION
For faster learning. But highlight spacebar as shift since on-screen keyboard don't have shift key.
![image](https://user-images.githubusercontent.com/13241662/117534118-4d73b900-b01a-11eb-9b45-403a2b5a46f9.png)
