### PR TITLE
:lipstick: show extra keys ( ']' and '\' ) in all keymap style

### DIFF
--- a/src/sass/style.scss
+++ b/src/sass/style.scss
@@ -3748,7 +3748,7 @@ key {
 
 .r5 {
   display: grid;
-  grid-template-columns: 3.5fr 6fr 3.5fr;
+  grid-template-columns: 3fr 6fr 4fr;
   font-size: 0.5rem;
   // &.matrixSpace {
   //   // grid-template-columns: 6.75fr 1.9fr 6.75fr;
@@ -3770,27 +3770,15 @@ key {
     .r1,
     .r2,
     .r3 {
-      grid-template-columns: 1.125fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr;
+      grid-template-columns: 1.125fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr;
     }
 
     .r4 {
-      grid-template-columns: 0fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr;
+      grid-template-columns: 0fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr;
     }
 
     .r5 {
-      grid-template-columns: 3.25fr 5fr 2fr 1fr;
-    }
-
-    .r1,
-    .r2,
-    .r3 {
-      :nth-child(13) {
-        opacity: 0;
-      }
-
-      :nth-child(14) {
-        opacity: 0;
-      }
+      grid-template-columns: 3.125fr 6.25fr 3fr 2fr;
     }
   }
   &.split {
@@ -3844,36 +3832,18 @@ key {
     .r1,
     .r2,
     .r3 {
-      grid-template-columns: 1.125fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr;
+      grid-template-columns: 1.125fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr;
     }
 
     .r4 {
-      grid-template-columns: 0fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr;
+      grid-template-columns: 0fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr;
     }
 
     .r5 {
-      grid-template-columns: 3.225fr 3fr 1fr 3fr 2fr;
+      grid-template-columns: 4fr 2fr 1fr 2fr 6fr;
     }
     #KeySpace2 {
       opacity: 1;
-    }
-
-    .r1 {
-      :nth-child(12) {
-        opacity: 0;
-      }
-    }
-
-    .r1,
-    .r2,
-    .r3 {
-      :nth-child(13) {
-        opacity: 0;
-      }
-
-      :nth-child(14) {
-        opacity: 0;
-      }
     }
   }
 }

--- a/static/index.html
+++ b/static/index.html
@@ -1192,7 +1192,7 @@
                   <div class="keymap-key" id="KeyRightBracket">
                     <span class="letter">]</span>
                   </div>
-                  <div class="keymap-key hidden-key" id="Backslash">
+                  <div class="keymap-key" id="Backslash">
                     <span class="letter">\</span>
                   </div>
                 </div>


### PR DESCRIPTION
Issue: 'ฯ' not display in all keymap style, 'o็', 'oื' and 'ฬ' both not display in matrix and split matrix style.

![image](https://user-images.githubusercontent.com/13241662/117542539-40b78b00-b043-11eb-9b3a-eed7f5385bf0.png)
![image](https://user-images.githubusercontent.com/13241662/117542548-4ad98980-b043-11eb-9046-44f6b63811ba.png)


This PR resolve it by show key for 'o็', 'oื', 'ฬ' and 'ฯ' in staggered, matrix, split and split matrix
Actually, for all currently available keymap style.

![image](https://user-images.githubusercontent.com/13241662/117542266-203b0100-b042-11eb-86cd-0850a1e977c4.png)
![image](https://user-images.githubusercontent.com/13241662/117542274-28933c00-b042-11eb-9509-f9ecb1a90a45.png)
